### PR TITLE
Some helpers for neatly injecting D3 visualizations into the notebooks

### DIFF
--- a/backstage/viz/__init__.py
+++ b/backstage/viz/__init__.py
@@ -1,0 +1,1 @@
+from .js2nb import inject_d3js

--- a/backstage/viz/js2nb.py
+++ b/backstage/viz/js2nb.py
@@ -8,7 +8,7 @@ import jinja2
 import json
 from IPython.display import HTML
 
-def inject_d3js(d3js_filename, style=None, d3js_template_options={}, local_d3_install=None):
+def inject_d3js(d3js_filename, style=None, d3js_template_options={}, local_d3_install=None, return_string=False):
     """
     Take in the filename of the D3.js script, assumed to be a Jinja2 template,
     and generate the necessary HTML, plus styling if selected, to display in a
@@ -33,7 +33,7 @@ def inject_d3js(d3js_filename, style=None, d3js_template_options={}, local_d3_in
     
     #grab the templates
     gen_template = env.get_template('inject_d3js.html')
-    d3js_template = env.get_template(d3js_filename)
+    d3js_template = env.get_template(os.path.basename(d3js_filename))
     
     #render the d3js file
     d3js_text = d3js_template.render(object_id='d3DummyId',**d3js_template_options)
@@ -41,5 +41,8 @@ def inject_d3js(d3js_filename, style=None, d3js_template_options={}, local_d3_in
     #render the general template
     gen_text = gen_template.render(object_id='d3DummyId', style_sheet=style, path_to_d3=path_to_d3, d3js_text=d3js_text)
     
-    return gen_text
+    if return_string:
+        return gen_text
+    else:
+        return HTML(gen_text)
     

--- a/backstage/viz/js2nb.py
+++ b/backstage/viz/js2nb.py
@@ -1,0 +1,45 @@
+"""
+Some basic functions for injecting Javascript into Jupyter notebooks
+"""
+
+import os
+
+import jinja2
+import json
+from IPython.display import HTML
+
+def inject_d3js(d3js_filename, style=None, d3js_template_options={}, local_d3_install=None):
+    """
+    Take in the filename of the D3.js script, assumed to be a Jinja2 template,
+    and generate the necessary HTML, plus styling if selected, to display in a
+    notebook.
+    """
+    
+    #configure environment
+    env = jinja2.Environment(loader=jinja2.FileSystemLoader([os.path.join(os.path.dirname(os.path.realpath(__file__)), 'templates/'), os.path.dirname(d3js_filename)]))
+    
+    #grab style from stylesheet if it exists
+    if style is None:
+        style = ''
+    else:
+        with open(style,'r') as f:
+            style = ''.join(f.readlines())
+            
+    #check if we've got a local install of d3.js 
+    if local_d3_install is not None:
+        path_to_d3 = local_d3_install
+    else:
+        path_to_d3 = 'https://cdnjs.cloudflare.com/ajax/libs/d3/4.2.2/d3.min.js'
+    
+    #grab the templates
+    gen_template = env.get_template('inject_d3js.html')
+    d3js_template = env.get_template(d3js_filename)
+    
+    #render the d3js file
+    d3js_text = d3js_template.render(object_id='d3DummyId',**d3js_template_options)
+    
+    #render the general template
+    gen_text = gen_template.render(object_id='d3DummyId', style_sheet=style, path_to_d3=path_to_d3, d3js_text=d3js_text)
+    
+    return gen_text
+    

--- a/backstage/viz/templates/inject_d3js.html
+++ b/backstage/viz/templates/inject_d3js.html
@@ -1,0 +1,4 @@
+<style>{{ style_sheet }}</style>
+<script src="{{ path_to_d3 }}"></script>
+<div id="{{ object_id }}"></div>
+<script>{{ d3js_text }}</script>

--- a/backstage/viz/templates/inject_d3js.html
+++ b/backstage/viz/templates/inject_d3js.html
@@ -1,4 +1,4 @@
 <style>{{ style_sheet }}</style>
 <script src="{{ path_to_d3 }}"></script>
-<div id="{{ object_id }}"></div>
+<div id="{{ object_id }}" class="d3container"></div>
 <script>{{ d3js_text }}</script>


### PR DESCRIPTION
The purpose of this function is to provide a way to inject a D3 visualization into a Jupyter notebook without having to write the javascript in the notebook. You can also pass data structures from Python to D3 to create visualizations from them.

As of now, I can't get the D3 CDN to work in the notebook, so the only option is to have a local (i.e. something in the notebook directory tree) install of d3. This is just one file so it isn't that big of a deal really...

@jdbrice maybe you know a bit more about the js side of this stuff? When I use

``` Python
HTML('<script src="https://d3js.org/d3.v4.min.js"></script>')
```

and then try to render the D3 viz, I get a `d3 undefined` from the Javascript console. Any idea why this is happening? [Somewhat related GitHub issue](https://github.com/mpld3/mpld3/issues/33)...
